### PR TITLE
Fix TypeScript build errors

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -13,7 +13,8 @@
       "Bash(npm run type-check:*)",
       "Bash(npm run build:*)",
       "Bash(# Move main entry point\nmv static/js/main.ts src/main.ts\n\n# Move type definitions\nmv static/js/types/index.ts src/types/index.ts\n\n# Move calculations\nmv static/js/calculations/geometry.ts src/calculations/geometry.ts\nmv static/js/calculations/archer.ts src/calculations/archer.ts\nmv static/js/calculations/exposure.ts src/calculations/exposure.ts\n\n# Move data files\nmv static/js/data/isotopes.ts src/data/isotopes.ts\nmv static/js/data/materials.ts src/data/materials.ts\n\n# Move UI components\nmv static/js/drawing.ts src/components/drawing.ts\nmv static/js/ui-controls.ts src/components/ui-controls.ts\nmv static/js/event-handlers.ts src/components/event-handlers.ts\n\n# Move utilities\nmv static/js/state.ts src/utils/state.ts\nmv static/js/constants.ts src/utils/constants.ts\n\n# Move client files (these seem to be components)\nmv static/js/heatmap-client.ts src/components/heatmap-client.ts\nmv static/js/calculations-client.ts src/components/calculations-client.ts)",
-      "Bash(true)"
+      "Bash(true)",
+      "Bash(git checkout:*)"
     ],
     "deny": []
   }

--- a/src/components/event-handlers.ts
+++ b/src/components/event-handlers.ts
@@ -204,7 +204,7 @@ export function handleCanvasMouseDown(event: MouseEvent): void {
     }
 }
 
-export function handleCanvasMouseUp(event: MouseEvent): void {
+export function handleCanvasMouseUp(_event: MouseEvent): void {
     if (isPanning && appState.canvas) {
         isPanning = false;
         appState.canvas.style.cursor = 'crosshair';

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,13 @@ import {
     updateUseBuildup, 
     resetArcherParams 
 } from './components/archer-ui';
+
+// Declare global functions
+declare global {
+    interface Window {
+        closeValidationInfo: () => void;
+    }
+}
 import { archerParams } from './utils/archer-params';
 import { calculateCeilingFloor } from './components/ceiling-floor-calc';
 


### PR DESCRIPTION
- Fix unused 'event' parameter warning by prefixing with underscore
- Add global type declaration for window.closeValidationInfo method

🤖 Generated with [Claude Code](https://claude.ai/code)